### PR TITLE
Get the root folders contributions distribution by contributors

### DIFF
--- a/src/analyze_contributions.py
+++ b/src/analyze_contributions.py
@@ -7,7 +7,9 @@ from collections import defaultdict
 def analyze_total_loc(repo_path):
     loc_data = defaultdict(lambda: {"added": 0, "deleted": 0})
     result = subprocess.run(
-        ["git", "log", "--numstat", "--pretty=%H", "-C", repo_path], stdout=subprocess.PIPE, text=True
+        ["git", "log", "--numstat", "--pretty=%H", "-C", repo_path],
+        stdout=subprocess.PIPE,
+        text=True,
     )
     lines = result.stdout.splitlines()
 
@@ -18,8 +20,12 @@ def analyze_total_loc(repo_path):
         elif "\t" in line and current_commit:
             added, deleted, _ = line.split("\t")
             try:
-                loc_data[current_commit]["added"] += int(added) if added.isdigit() else 0
-                loc_data[current_commit]["deleted"] += int(deleted) if deleted.isdigit() else 0
+                loc_data[current_commit]["added"] += (
+                    int(added) if added.isdigit() else 0
+                )
+                loc_data[current_commit]["deleted"] += (
+                    int(deleted) if deleted.isdigit() else 0
+                )
             except ValueError:
                 print(f"Skipping binary file entry in commit {current_commit}: {line}")
 
@@ -29,7 +35,11 @@ def analyze_total_loc(repo_path):
 def analyze_final_loc(repo_path):
     # Get all tracked files without changing directories
     result = subprocess.run(
-        ["git", "-C", repo_path, "ls-files"], stdout=subprocess.PIPE, text=True, encoding="utf-8", errors="replace"
+        ["git", "-C", repo_path, "ls-files"],
+        stdout=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
     )
     files = result.stdout.splitlines()
 
@@ -50,6 +60,99 @@ def analyze_final_loc(repo_path):
                 final_loc[author] += 1
 
     return final_loc
+
+
+def analyze_contribution_per_root_folder(repo_path):
+    # For each contributor commits
+    # List the modified file path
+    # Get the root folder
+    # Add +1 to root folder
+    # Display the % of root folder contribution for the contributor
+
+    # Get all contributors
+    result = subprocess.run(
+        ["git", "-C", repo_path, "shortlog", "-sne"],
+        stdout=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    contributors = result.stdout.splitlines()
+
+    root_folder_contributions = {}
+    for contributor in contributors:
+        # Get the contributor name
+        contributor_name = contributor.split("\t")[-1].strip()
+        contributor_name = contributor_name.split("<")[0].strip()
+        root_folder_contributions[contributor_name] = defaultdict(int)
+
+        # Get the contributor commits
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                repo_path,
+                "log",
+                "--author=" + contributor_name,
+                "--pretty=%H",
+            ],
+            stdout=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        commits = result.stdout.splitlines()
+
+        # Get the modified files for each commit
+        for commit in commits:
+            this_commit_root_folders = set()
+            result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    repo_path,
+                    "show",
+                    "--name-only",
+                    "--pretty=",
+                    "--oneline",
+                    commit,
+                ],
+                stdout=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            files = result.stdout.splitlines()
+
+            # Ignore the commit message (first line)
+            files = files[1:]
+
+            # Get the root folder for each modified file
+            for file in files:
+                root_folder = file.split("/", 1)[0]
+                if not root_folder:
+                    continue
+
+                # Add the root folder to the set (so that we only count it once per commit)
+                this_commit_root_folders.add(root_folder)
+
+            # Add +1 to each root folder
+            for root_folder in this_commit_root_folders:
+                root_folder_contributions[contributor_name][root_folder] += 1
+
+        # Sort the root folders by contribution
+        root_folder_contributions[contributor_name] = dict(
+            sorted(
+                root_folder_contributions[contributor_name].items(),
+                key=lambda item: item[1],
+                reverse=True,
+            )
+        )
+
+        print(f"Contributor: {contributor_name}")
+        print(f"Total LOC: {root_folder_contributions[contributor_name]}")
+
+    return root_folder_contributions
 
 
 def merge_accounts(final_loc, account_mapping):
@@ -78,10 +181,13 @@ def generate_report(repos, account_mapping=None, output_dir="."):
 
     for repo_url, repo_path in repos.items():
         print(f"Analyzing repository: {repo_url}")
-        
+
         # Analyze LOC
         total_loc = analyze_total_loc(repo_path)
         final_loc = analyze_final_loc(repo_path)
+
+        # Analyze contribution per root folder
+        root_folder_loc = analyze_contribution_per_root_folder(repo_path)
 
         # Merge accounts if mapping is provided
         if account_mapping:
@@ -91,6 +197,7 @@ def generate_report(repos, account_mapping=None, output_dir="."):
         report = {
             "Total LOC": total_loc,
             "Final LOC": final_loc,
+            "Root Folder LOC": root_folder_loc,
         }
 
         # Build the file name for the report

--- a/src/clone_repo.py
+++ b/src/clone_repo.py
@@ -11,7 +11,7 @@ def clone_repo(repo_url, repo_dir):
     try:
         if os.path.exists(repo_dir):
             print(f"Directory '{repo_dir}' already exists. Skipping clone for '{repo_url}'.")
-            return False
+            return True
 
         git.Repo.clone_from(repo_url, repo_dir)
         print(f"Successfully cloned '{repo_url}' into '{repo_dir}'")


### PR DESCRIPTION
Added a function in `analyze_contributions.py` to get the number of commit made of the root folders (see #9)

Results examples : 
![image](https://github.com/user-attachments/assets/12154855-53ee-451a-ba85-91bba8f1029e)
